### PR TITLE
properly builds pjproject with alsa support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-trunk
+pjproject
 tools
-includes
-install
+thirdparty
 pjsua.cfg


### PR DESCRIPTION
fetches prebuilt alsa packages instead of cross-compiling
provides a description of how to enable audio in the raspberry